### PR TITLE
Update version in package.json to 1.1.0 (#9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-wordy",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "Thesaurus, dictionary and more using the Datamuse API",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
Addresses issue #9 by updating the plugin version in package.json to reflect the correct current version. This should allow obsidian to automatically update the plugin for users who have not manually installed the updated version.